### PR TITLE
Dockerfile: Pin to Jira 1.0.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN dnf install -qy \
  && dnf clean all \
  && pip install --no-cache-dir -q \
        requests \
-       jira \
+       jira==1.0.3 \
        pep8 \
        pylint \
        demjson


### PR DESCRIPTION
In Jira 1.0.7, the current release, the search_issues()
query in tickets.py:60 falis in jira/client.py with
a keyerror, presumably related to the keyword arguments
we pass in.   Version 1.0.3 does not have this problem.

Signed-off-by: Euan Harris euan.harris@citrix.com
